### PR TITLE
Enhance error handling logic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ feedparser==6.0.10
 Mastodon.py==1.8.0
 requests==2.28.1
 twint @ git+https://github.com/woluxwolu/twint.git
-yt-dlp==2023.1.6
+yt-dlp==2023.03.04
+

--- a/tootbot.py
+++ b/tootbot.py
@@ -320,7 +320,7 @@ else:
                         target_audio_bitrate_kbit_s = audio_bitrate_dec / Decimal(1000.0)
                         target_video_bitrate_kbit_s = (Decimal(MAX_VIDEO_SIZE_MB) * Decimal(8192.0)) / (Decimal(1.048576) * duration_dec) - target_audio_bitrate_kbit_s
                         
-                        if target_video_bitrate_kbit_s <= 0:
+                        if target_video_bitrate_kbit_s <= Decimal(0):
                             raise Exception('result in negative bitrate ', target_video_bitrate_kbit_s)
                         
                         subprocess.run('rm -f ffmpeg2pass*', shell=True, capture_output=False)

--- a/tootbot.py
+++ b/tootbot.py
@@ -288,7 +288,7 @@ else:
             else:
                 c = c.replace(l, '')
 
-            m = re.search(r'(twitter.com/.*/video/|youtube.com)', redir)
+            m = re.search(r'(twitter.com/.*/video/)', redir)
             if m is None:
                 c = c.replace(l, redir)
             else:


### PR DESCRIPTION
Related to https://github.com/cquest/tootbot/issues/26 and another issue I had where the server takes more than the 5 + 10 seconds to process the post media, I made these changes which work well for me.

I know that matching human localized string is fragile and not a good practice, but we don't have really the choice with Mastodon API apparently.

I'm not a Python developer, so there is chance it was possible to fix that differently, in a more Python-ish way.

Feel free to comment and/or if you are interested.

(P.-S. I also updated yt-dlp because it was failing frequently)